### PR TITLE
Make the Redis connection more robust

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ if (process.env.REDIS_SECRET) {
   client.auth(process.env.REDIS_SECRET);
 }
 
+client.on('error', function (err) {
+  console.log('Redis client error: ' + err);
+});
 
 app.use(function* () {
 


### PR DESCRIPTION
When Redis resets the connection, the ECONNRESET error cause the nodejs server
to exit. Capture and log it so that the server lives on and reconnects. Perhaps after enough logging we'll learn that different errors require different handling.
