### PR TITLE
Update to work with current-content key

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,7 @@ app.use(co.wrap(function* (ctx) {
   if (ctx.request.query.index_key) {
     indexkey = process.env.APP_NAME +':'+ ctx.request.query.index_key;
   } else {
-    indexkey = yield dbCo.get(process.env.APP_NAME +':current');
-    indexkey = process.env.APP_NAME + ':' + indexkey;
+    indexkey = process.env.APP_NAME +':current-content';
   }
   var index = yield dbCo.get(indexkey);
 


### PR DESCRIPTION
This key is populated by ember deploy by default now and is a simpler
way to get the current revision's content.
