### PR TITLE
Trap SIGINT and exit cleanly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12-onbuild
+FROM node:4-onbuild
 
 EXPOSE 3000
 

--- a/index.js
+++ b/index.js
@@ -38,4 +38,10 @@ app.use(co.wrap(function* (ctx) {
   }
 }));
 
-app.listen(process.env.PORT || 3000);
+var server = app.listen(process.env.PORT || 3000);
+
+process.on('SIGINT', function () {
+  server.close(function () {
+    process.exit(0);
+  });
+});


### PR DESCRIPTION
Allow ^C to stop the server when running in an interactive docker container.
