### PR TITLE
Stop using the node onbuild image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9-onbuild
+FROM node:9
 
 EXPOSE 3000
 
@@ -6,5 +6,10 @@ ENV APP_NAME ""
 ENV REDIS_PORT 6379
 ENV REDIS_HOST redis
 ENV REDIS_SECRET ""
+
+WORKDIR /usr/src/app
+COPY package.json /usr/src/app/
+RUN npm install && npm cache clean --force
+COPY . /usr/src/app
 
 CMD [ "node", "--harmony", "index.js" ]


### PR DESCRIPTION
ONBUILD is deprecated, and so copy the relevant commands from the parent image.